### PR TITLE
fix: subText styling and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,14 @@ Macro
     * @param {string} colorSecond  Hex value for the color of the middle bar in the banner.
     * @param {string} colorThird  Hex value for the color of the middle bar in the banner.
     * @param {string} colorFont  Hex value for the text color of the message.
+    * @param {string} subColorFont  Hex value for the text color of the subText.
     * @param {string} colorShadow  Hex value for the drop shadow color of the message.
+    * @param {string} subColorShadow  Hex value for the drop shadow color of the subText.
     * @param {string} message  The message to be rendered in the color bar. {{actor.name}} and {{token.name}} will be replaced with the appropate name
+    * @param {string} subText  The sub message to be rendered in the second color bar.
     * @param {string} fontFamily Font Family name for the message.
     * @param {string} fontSize CSS accepted Size of font.
+    * @param {string} subFontSize CSS accepted Size of font for subText.
     * @param {string} actorImg  Path to an image to display on the banner.
     * @param {number} timer  Number of miliseconds for splash screen to be rendered.
     * @param {number} animationDuration  Number of seconds to complete the slide in animation.
@@ -53,10 +57,14 @@ let options = {
   colorSecond:null,
   colorThird: null, 
   colorFont: null,
+  subColorFont: null,
   colorShadow: null,
+  subColorShadow: null,
   message: null, 
+  subText: null,
   fontFamily: null,
   fontSize: null,
+  subFontSize: null,
   actorImg: null,
   timer: null,
   animationDuration: null,

--- a/css/boss-splash.css
+++ b/css/boss-splash.css
@@ -63,7 +63,8 @@
 
 .colorSecond h3 {
   position: relative;
-  margin-right: 20%;
+  text-align: right;
+  margin-right: 25%;
   top: -10px;
   border-bottom:none;
 }
@@ -92,5 +93,15 @@
 
   to {
     margin-right: 20%;
+  }
+}
+
+@keyframes sub-slide-right {
+  from {
+    margin-right: 30%;
+  }
+
+  to {
+    margin-right: 25%;
   }
 }

--- a/templates/boss-splash.hbs
+++ b/templates/boss-splash.hbs
@@ -6,6 +6,11 @@
   animation-name:  slide-right;
 }
 
+.sub-slide-right {
+  animation-duration: {{animationDuration}}s;
+  animation-name: sub-slide-right;
+}
+
 .slide-left { 
   animation-duration: {{animationDuration}}s;
   animation-name:  slide-left;
@@ -21,9 +26,11 @@
           </h2>
     </div>
     <div class='colorSecond' style="background-color: {{colorSecond}}">
-          <h3 name="bossSubText" class="slide-right" style="color: {{subColorFont}}; text-shadow: 3px 3px {{subColorShadow}}; font-family: {{fontFamily}}; font-size: {{subFontSize}}">
+          {{#if subText}}
+          <h3 name="bossSubText" class="sub-slide-right" style="color: {{subColorFont}}; text-shadow: 3px 3px {{subColorShadow}}; font-family: {{fontFamily}}; font-size: {{subFontSize}}">
           {{subText}}
           </h3>
+          {{/if}}
     </div>
     <div class='colorThird'  style="background-color: {{colorThird}}"></div>
   </div>


### PR DESCRIPTION
Hey @jsavko sorry for the incomplete previous MR.

This fixes the bad styling (and ugly gap I didn't intend to exist when the `subText` was set to `null`).

I also updated the README.

This was requested by several GMs I play with who thought your module was very cool but lacking this key feature! I know they'll enjoy being able to specify the subText in their invocation macro!

Maybe in the future another method of generating the subtext based on the token/actor selected could be implemented. Until then I think this is pretty useful.

#21 